### PR TITLE
address rules for Poland

### DIFF
--- a/resources/styles/default/inc/address
+++ b/resources/styles/default/inc/address
@@ -31,8 +31,10 @@ mkgmap:country=AUT & mkgmap:city!=* & mkgmap:admin_level10=* { set mkgmap:city='
 mkgmap:country=AUT & mkgmap:city!=* & mkgmap:admin_level8=* { set mkgmap:city='${mkgmap:admin_level8|subst:Gemeinde |subst:Stadt }' }
 
 # Poland = POL
-mkgmap:country=POL & mkgmap:city!=* & mkgmap:admin_level10=* { set mkgmap:city='${mkgmap:admin_level10}' }
+#After recent changes in OSM-Poland we don't use level 10 - all cities and villages are in level 8
+#mkgmap:country=POL & mkgmap:city!=* & mkgmap:admin_level10=* { set mkgmap:city='${mkgmap:admin_level10}' }
 mkgmap:country=POL & mkgmap:city!=* & mkgmap:admin_level8=* { set mkgmap:city='${mkgmap:admin_level8}' }
+
 mkgmap:country=POL & mkgmap:region!=* & mkgmap:admin_level4=* { set mkgmap:region='${mkgmap:admin_level4|subst:województwo =>}' }
 
 # other european countries


### PR DESCRIPTION
In OSM-Poland we recently changes administrative boundary classification - we don't use level10 anymore.
